### PR TITLE
Update ActiveSupport to 6.1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,27 +2,27 @@ PATH
   remote: .
   specs:
     hyperwallet-ruby (0.1.0)
-      activesupport (~> 6.0.3.2)
+      activesupport (~> 6.1.3.1)
       faraday (~> 0.17.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.3)
-    faraday (0.17.3)
+    faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
-    i18n (1.8.3)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.1)
+    minitest (5.14.4)
     multipart-post (2.1.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -41,10 +41,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/hyperwallet-ruby.gemspec
+++ b/hyperwallet-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport',       "~> 6.0.3.2"
+  s.add_dependency 'activesupport',       "~> 6.1.3.1"
   s.add_dependency "faraday",             "~> 0.17.3"
   s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "rake",    "~> 13.0"


### PR DESCRIPTION
### Context

Licence changes in `mimemagic` gem prevented build to be completed in rails with versions `~> 6.0`. Updating Rails and its Active dependencies to `~ >6.1` is required. 
In turn, this gem's dependency on ActiveSupport `~> 6.0` must be updated.  

### Changes

- Update ActiveSupport to version `6.1.3.1`


