### PR TITLE
Update API version

### DIFF
--- a/lib/hyperwallet/api/client.rb
+++ b/lib/hyperwallet/api/client.rb
@@ -47,8 +47,8 @@ class Hyperwallet::Api::Client < Hyperwallet::Api::Config
     base_url + "/" + resource
   end
 
-  def base_url 
-    active_url + API_VERSION
+  def base_url
+    active_url + self.class.superclass.api_version
   end
 
   def active_url

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -5,7 +5,7 @@ module Hyperwallet
       PRODUCTION_URL     = "https://api.paylution.com/rest"
       UAT_URL            = "https://uat-api.paylution.com/rest"
 
-      API_VERSION = "/v4/users"
+      API_VERSION = "/v4"
       MODES       = [:uat, :production]
 
       class << self

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -4,9 +4,7 @@ module Hyperwallet
 
       PRODUCTION_URL     = "https://api.paylution.com/rest"
       UAT_URL            = "https://uat-api.paylution.com/rest"
-
-      API_VERSION = "/v4"
-      MODES       = [:uat, :production]
+      MODES              = [:uat, :production]
 
       class << self
         attr_accessor :api_user, :api_password, :api_mode, :proxy
@@ -16,6 +14,12 @@ module Hyperwallet
 
         def production?
           api_mode == :production
+        end
+
+        def api_version
+          return "/v3" if production?
+
+          "/v4"
         end
       end
     end

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -2,11 +2,11 @@ module Hyperwallet
   module Api
     class Config
 
-      PRODUCTION_URL     = "https://api.paylution.com/rest"
-      UAT_URL            = "https://uat-api.paylution.com/rest"
+      PRODUCTION_URL         = "https://api.paylution.com/rest"
+      UAT_URL                = "https://uat-api.paylution.com/rest"
       PRODUCTION_API_VERSION = "/v3"
-      UAT_API_VERSION = "/v4"
-      MODES              = [:uat, :production]
+      UAT_API_VERSION        = "/v4"
+      MODES                  = [:uat, :production]
 
       class << self
         attr_accessor :api_user, :api_password, :api_mode, :proxy

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -4,6 +4,8 @@ module Hyperwallet
 
       PRODUCTION_URL     = "https://api.paylution.com/rest"
       UAT_URL            = "https://uat-api.paylution.com/rest"
+      PRODUCTION_API_VERSION = "/v3"
+      UAT_API_VERSION = "/v4"
       MODES              = [:uat, :production]
 
       class << self
@@ -17,9 +19,9 @@ module Hyperwallet
         end
 
         def api_version
-          return "/v3" if production?
+          return PRODUCTION_API_VERSION if production?
 
-          "/v4"
+          UAT_API_VERSION
         end
       end
     end

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -5,7 +5,7 @@ module Hyperwallet
       PRODUCTION_URL     = "https://api.paylution.com/rest"
       UAT_URL            = "https://uat-api.paylution.com/rest"
 
-      API_VERSION = "/v4"
+      API_VERSION = "/v4/users"
       MODES       = [:uat, :production]
 
       class << self

--- a/lib/hyperwallet/api/config.rb
+++ b/lib/hyperwallet/api/config.rb
@@ -5,7 +5,7 @@ module Hyperwallet
       PRODUCTION_URL     = "https://api.paylution.com/rest"
       UAT_URL            = "https://uat-api.paylution.com/rest"
 
-      API_VERSION = "/v3"
+      API_VERSION = "/v4"
       MODES       = [:uat, :production]
 
       class << self


### PR DESCRIPTION
The Hyperwallet Sandbox is only compatible with API v4, while our production environment currently relies on API v3. Because of this limitation, conditional logic was required to support both versions depending on the environment.